### PR TITLE
feat: add apache template

### DIFF
--- a/modules/logs/input-templates.d/apache2.yml
+++ b/modules/logs/input-templates.d/apache2.yml
@@ -1,0 +1,117 @@
+{{#MORIO_DOCS}}
+about: |-
+  A filebeat module for Linux systems
+
+  This collects access log data from the Apache 2.x HTTP Server. It autodetects and supports the following log file formats:
+  - common
+  - combined
+  - vhost_combined
+  If the logs are to be sent to a Splunk ecosystem, you can set the MORIO_APACHE_SPLUNK_INDEX_NAME Morio variable to specify the name of the Splunk index to use.
+{{/MORIO_DOCS}}
+
+{{^MORIO_DOCS}}
+
+# This module collects all Apache logs
+- type: log
+  id: apache2_everything
+  paths:
+    - /var/log/apache2/*.log
+
+  processors:
+    - add_fields:
+        target: morio
+        fields:
+          module: {{ MORIO_MODULE_NAME }}
+
+    - add_fields:
+        target: host
+        fields:
+          id: {{ MORIO_CLIENT_UUID }}
+
+    - add_fields:
+        target: debug
+        fields:
+          iteration: "1543"
+
+    - if:
+        regexp:
+          message: '^[^:].*:\d{1,3} ' # LogFormat vhost_combined
+      then:
+        - dissect:
+            field: "message"
+            tokenizer: "%{http.server.name}:%{http.server.port} %{source.ip} %{http.auth_type} %{http.username} [%{temp_timestamp}] \"%{http.request.method} %{url.original} %{http.version}\" %{http.response.status_code} %{http.response.body.bytes} \"%{url.original}\" \"%{user_agent.original}\""
+            target_prefix: ''
+            ignore_missing: true
+            ignore_failure: true
+            overwrite_keys: true
+        - add_fields:
+            target: log
+            fields:
+              detected_format: "vhost_combined"
+        - timestamp:
+            field: temp_timestamp
+            layouts:
+              - '02/Jan/2006:15:04:05 -0700'
+            ignore_missing: true
+            ignore_failure: true
+        - drop_fields:
+            fields: temp_timestamp
+            ignore_missing: true
+
+    - if:
+        regexp:
+          message: '^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} .+ \d+ \d+ .+$' # LogFormat combined
+      then:
+        - dissect:
+            field: "message"
+            tokenizer: "%{source.ip} %{http.auth_type} %{http.username} [%{temp_timestamp}] \"%{http.request.method} %{url.original} %{http.version}\" %{http.response.status_code} %{http.response.body.bytes} \"%{url.original}\" \"%{user_agent.original}\""
+            target_prefix: ''
+            ignore_missing: true
+            ignore_failure: true
+            overwrite_keys: true
+        - add_fields:
+            target: log
+            fields:
+              detected_format: "combined"
+        - timestamp:
+            field: temp_timestamp
+            layouts:
+              - '02/Jan/2006:15:04:05 -0700'
+            ignore_missing: true
+            ignore_failure: true
+        - drop_fields:
+            fields: temp_timestamp
+            ignore_missing: true
+
+    - if:
+        regexp:
+          message: '^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3} .+ \d+ \d+$' # LogFormat common
+      then:
+        - dissect:
+            field: "message"
+            tokenizer: "%{source.ip} %{http.auth_type} %{http.username} [%{temp_timestamp}] \"%{http.request.method} %{url.original} %{http.version}\" %{http.response.status_code} %{http.response.body.bytes}"
+            target_prefix: ''
+            ignore_missing: true
+            ignore_failure: true
+            overwrite_keys: true
+        - add_fields:
+            target: log
+            fields:
+              detected_format: "common"
+        - timestamp:
+            field: temp_timestamp
+            layouts:
+              - '02/Jan/2006:15:04:05 -0700'
+        - drop_fields:
+            fields: temp_timestamp
+            ignore_missing: true
+
+    {{#MORIO_APACHE_SPLUNK_INDEX_NAME }}
+    - add_fields:
+        target: splunk
+        fields:
+          index: {{ MORIO_APACHE_SPLUNK_INDEX_NAME }}
+    {{/MORIO_APACHE_SPLUNK_INDEX_NAME }}
+
+{{/MORIO_DOCS}}
+

--- a/modules/logs/input-templates.d/apache2.yml
+++ b/modules/logs/input-templates.d/apache2.yml
@@ -2,20 +2,21 @@
 about: |-
   A filebeat module for Linux systems
 
-  This collects access log data from the Apache 2.x HTTP Server. It autodetects and supports the following log file formats:
-  - common
-  - combined
-  - vhost_combined
+  This collects access and error log data from the Apache 2.x HTTP Server. It autodetects and supports the following log file formats:
+  - access: common
+  - access: combined
+  - access: vhost_combined
+  - error: default (without client IP)
+
   If the logs are to be sent to a Splunk ecosystem, you can set the MORIO_APACHE_SPLUNK_INDEX_NAME Morio variable to specify the name of the Splunk index to use.
 {{/MORIO_DOCS}}
 
 {{^MORIO_DOCS}}
 
-# This module collects all Apache logs
-- type: log
-  id: apache2_everything
+- type: log # This collects all Apache error logs
+  id: apache2_error
   paths:
-    - /var/log/apache2/*.log
+    - /var/log/apache2/*error*.log
 
   processors:
     - add_fields:
@@ -31,11 +32,63 @@ about: |-
     - add_fields:
         target: debug
         fields:
-          iteration: "1543"
+          iteration: "1140"
 
     - if:
         regexp:
-          message: '^[^:].*:\d{1,3} ' # LogFormat vhost_combined
+          message: '^\[.+\]\s\[.+\]\s\[.*\sAH[0-9]{5}:.*' # default ErrorLogFormat
+      then:
+        - dissect:
+            field: "message"
+            tokenizer: "[%{temp_timestamp}] [%{event.module}:%{log.level}] [pid %{process.pid}:tid %{thread.id}] %{error.code}: %{event.message}"
+            target_prefix: ''
+            ignore_missing: true
+            ignore_failure: true
+            overwrite_keys: true
+        - add_fields:
+            target: log
+            fields:
+              detected_format: "default"
+
+    - timestamp:
+        field: temp_timestamp
+        layouts:
+          - 'Mon Jan 02 15:04:05.999999 2006'
+    - drop_fields:
+        fields: temp_timestamp
+
+    {{#MORIO_APACHE_SPLUNK_INDEX_NAME }}
+    - add_fields:
+        target: splunk
+        fields:
+          index: {{ MORIO_APACHE_SPLUNK_INDEX_NAME }}
+    {{/MORIO_APACHE_SPLUNK_INDEX_NAME }}
+
+
+- type: log # This collects all Apache access logs
+  id: apache2_access
+  paths:
+    - /var/log/apache2/*access*.log
+
+  processors:
+    - add_fields:
+        target: morio
+        fields:
+          module: {{ MORIO_MODULE_NAME }}
+
+    - add_fields:
+        target: host
+        fields:
+          id: {{ MORIO_CLIENT_UUID }}
+
+    - add_fields:
+        target: debug
+        fields:
+          iteration: "AAAE"
+
+    - if:
+        regexp:
+          message: '^[^:\s]+:\d{1,3}\s\d{1,3}.' # LogFormat vhost_combined
       then:
         - dissect:
             field: "message"
@@ -48,15 +101,6 @@ about: |-
             target: log
             fields:
               detected_format: "vhost_combined"
-        - timestamp:
-            field: temp_timestamp
-            layouts:
-              - '02/Jan/2006:15:04:05 -0700'
-            ignore_missing: true
-            ignore_failure: true
-        - drop_fields:
-            fields: temp_timestamp
-            ignore_missing: true
 
     - if:
         regexp:
@@ -73,15 +117,6 @@ about: |-
             target: log
             fields:
               detected_format: "combined"
-        - timestamp:
-            field: temp_timestamp
-            layouts:
-              - '02/Jan/2006:15:04:05 -0700'
-            ignore_missing: true
-            ignore_failure: true
-        - drop_fields:
-            fields: temp_timestamp
-            ignore_missing: true
 
     - if:
         regexp:
@@ -98,13 +133,13 @@ about: |-
             target: log
             fields:
               detected_format: "common"
-        - timestamp:
-            field: temp_timestamp
-            layouts:
-              - '02/Jan/2006:15:04:05 -0700'
-        - drop_fields:
-            fields: temp_timestamp
-            ignore_missing: true
+
+    - timestamp:
+        field: temp_timestamp
+        layouts:
+          - '02/Jan/2006:15:04:05 -0700'
+    - drop_fields:
+        fields: temp_timestamp
 
     {{#MORIO_APACHE_SPLUNK_INDEX_NAME }}
     - add_fields:

--- a/modules/logs/input-templates.d/linux-system.yml
+++ b/modules/logs/input-templates.d/linux-system.yml
@@ -3,16 +3,41 @@ about: |-
   A filebeat module for Linux systems
 
   This collects log data from journald.
+
+  If the logs are to be sent to a Splunk ecosystem, you can set the MORIO_JOURNALD_SPLUNK_INDEX_NAME Morio variable to specify the name of the Splunk index to use.
 {{/MORIO_DOCS}}
 
 {{^MORIO_DOCS}}
-# This module collects all journald data
-- type: journald
+
+- type: journald # This module collects all journald data
   id: journald_everything
   processors:
     - add_fields:
         target: morio
         fields:
           module: {{ MORIO_MODULE_NAME }}
+
+    - rename:
+        fields:
+          - from: "message"
+            to: "event.message"
+
+    - add_fields:
+        target: host
+        fields:
+          id: {{ MORIO_CLIENT_UUID }}
+
+    - add_fields:
+        target: debug
+        fields:
+          iteration: "AAAD"
+
+    {{#MORIO_JOURNALD_SPLUNK_INDEX_NAME }}
+    - add_fields:
+        target: splunk
+        fields:
+          index: {{ MORIO_JOURNALD_SPLUNK_INDEX_NAME }}
+    {{/MORIO_JOURNALD_SPLUNK_INDEX_NAME }}
+
 {{/MORIO_DOCS}}
 

--- a/modules/logs/module-templates.d/apache2.yml
+++ b/modules/logs/module-templates.d/apache2.yml
@@ -1,0 +1,5 @@
+# noop
+#
+# Filebeat does not list inputs as modules.
+# So we keep an empty file here to make sure this shows up as a Filebeat module.
+#


### PR DESCRIPTION
A filebeat module for Linux systems

This collects access and error log data from the Apache 2.x HTTP Server. It autodetects and supports the following log file formats:
- access: common
- access: combined
- access: vhost_combined
- error: default (without client IP)

If the logs are to be sent to a Splunk ecosystem, you can set the MORIO_APACHE_SPLUNK_INDEX_NAME Morio variable to specify the name of the Splunk index to use.